### PR TITLE
disable connection to psql

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,9 @@
 import http from "http";
 
 import app from "./app";
-import { connectDb, disconnectDb } from "./db";
+
+
+// import { connectDb, disconnectDb } from "./db";
 
 const port = parseInt(process.env.PORT || "3000");
 
@@ -14,6 +16,8 @@ server.on("listening", () => {
 	console.log(`Listening on ${bind}`);
 });
 
-process.on("SIGTERM", () => server.close(() => disconnectDb()));
+// psql connection handling - currently unused
+// process.on("SIGTERM", () => server.close(() => disconnectDb()));
+// connectDb().then(() => server.listen(port));
 
-connectDb().then(() => server.listen(port));
+server.listen(port);


### PR DESCRIPTION
Disable Psql connection checking on backend server startup and shutdown.

## Context

To get started we want a working backend server without having to do the full laborious setup of the psql server on each developer's machine. 